### PR TITLE
Enforces spaces after commas

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'no-eval': 2,
     'no-lone-blocks': 2,
     'no-lonely-if': 2,
+    'comma-spacing': [2, {'before': false, 'after': true}],
     'no-trailing-spaces': 2,
     'no-undefined': 2,
     'no-unused-vars': [2, { 'args': 'none' }],


### PR DESCRIPTION
And disallows spacing before commas

Handlebars.registerPartial('partial-header',templates['public.common.partial-header'])
is not valid, but the following one is
Handlebars.registerPartial('partial-header', templates['public.common.partial-header'])
