### PR TITLE
Enforces spaces on inline operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'no-eval': 2,
     'no-lone-blocks': 2,
     'no-lonely-if': 2,
+    'space-infix-ops': ['error', {'int32Hint': false}],
     'no-trailing-spaces': 2,
     'no-undefined': 2,
     'no-unused-vars': [2, { 'args': 'none' }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-meedoc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shared eslint rules for MeeDoc js applications.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
AKA solution-to-terniary-operator-huge-blocks 
The new rule will introduce 30 Errors on the patient website (operators without space separation), do not merge if you are not ready to fix the new linting errors

http://eslint.org/docs/rules/space-infix-ops
